### PR TITLE
Adds three options for exporting: Visible, Invisible and All level items

### DIFF
--- a/SADXLVL2/MainForm.cs
+++ b/SADXLVL2/MainForm.cs
@@ -2524,8 +2524,9 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					objstream.WriteLine("mtllib " + Path.GetFileNameWithoutExtension(a.FileName) + ".mtl");
 
-                    int levelItemsCount = LevelData.LevelItems.Count(v => mode == exportModes.all || (mode == exportModes.visible && v.Visible) || (mode == exportModes.invisible && !v.Visible));
-                    int stepCount = LevelData.TextureBitmaps[LevelData.leveltexs].Length + levelItemsCount;
+                    List<LevelItem> levelItemsExport = LevelData.LevelItems.Where(v => mode == exportModes.all || (mode == exportModes.visible && v.Visible) || (mode == exportModes.invisible && !v.Visible)).ToList();
+
+                    int stepCount = LevelData.TextureBitmaps[LevelData.leveltexs].Length + levelItemsExport.Count;
 					if (LevelData.geo.Anim != null)
 						stepCount += LevelData.geo.Anim.Count;
 
@@ -2565,17 +2566,15 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					bool errorFlag = false;
 
-					for (int i = 0; i < LevelData.geo.COL.Count; i++)
+					for (int i = 0; i < levelItemsExport.Count; i++)
 					{
-                        if (mode == exportModes.all || (mode == exportModes.visible && LevelData.LevelItems[i].Visible) || (mode == exportModes.invisible && !LevelData.LevelItems[i].Visible))
-                        {
-                            Direct3D.Extensions.WriteModelAsObj(objstream, LevelData.geo.COL[i].Model, materialPrefix, new MatrixStack(),
-                                ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);
+                        //if (mode == exportModes.all || (mode == exportModes.visible && LevelData.LevelItems[i].Visible) || (mode == exportModes.invisible && !LevelData.LevelItems[i].Visible))
+                        Direct3D.Extensions.WriteModelAsObj(objstream, levelItemsExport[i].CollisionData.Model, materialPrefix, new MatrixStack(),
+                            ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);
 
-                            progress.Step = String.Format("Mesh {0}/{1}", i + 1, levelItemsCount);
-                            progress.StepProgress();
-                            Application.DoEvents();
-                        }
+                        progress.Step = String.Format("Mesh {0}/{1}", i + 1, levelItemsExport.Count);
+                        progress.StepProgress();
+                        Application.DoEvents();
 					}
 					if (LevelData.geo.Anim != null)
 					{

--- a/SADXLVL2/MainForm.cs
+++ b/SADXLVL2/MainForm.cs
@@ -2484,7 +2484,22 @@ namespace SonicRetro.SAModel.SADXLVL2
 				}
 		}
 
-		private void exportOBJToolStripMenuItem_Click(object sender, EventArgs e)
+        private void allToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            exportOBJ(0);
+        }
+
+        private void visibleToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            exportOBJ(1);
+        }
+
+        private void invisibleToolStripMenuItem1_Click(object sender, EventArgs e)
+        {
+            exportOBJ(2);
+        }
+
+        private void exportOBJ(int mode)
 		{
 			SaveFileDialog a = new SaveFileDialog
 			{
@@ -2543,12 +2558,15 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					for (int i = 0; i < LevelData.geo.COL.Count; i++)
 					{
-						Direct3D.Extensions.WriteModelAsObj(objstream, LevelData.geo.COL[i].Model, materialPrefix, new MatrixStack(),
-							ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);
+                        if (mode == 0 || (mode == 1 && LevelData.LevelItems[i].Visible) || (mode == 2 && !LevelData.LevelItems[i].Visible))
+                        {
+                            Direct3D.Extensions.WriteModelAsObj(objstream, LevelData.geo.COL[i].Model, materialPrefix, new MatrixStack(),
+                                ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);
 
-						progress.Step = String.Format("Mesh {0}/{1}", i + 1, LevelData.geo.COL.Count);
-						progress.StepProgress();
-						Application.DoEvents();
+                            progress.Step = String.Format("Mesh {0}/{1}", i + 1, LevelData.geo.COL.Count);
+                            progress.StepProgress();
+                            Application.DoEvents();
+                        }
 					}
 					if (LevelData.geo.Anim != null)
 					{
@@ -2896,5 +2914,5 @@ namespace SonicRetro.SAModel.SADXLVL2
 			foreach (LevelItem item in LevelData.LevelItems)
 				item.CalculateBounds();
 		}
-	}
+    }
 }

--- a/SADXLVL2/MainForm.cs
+++ b/SADXLVL2/MainForm.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -12,6 +12,7 @@ using Microsoft.DirectX.Direct3D;
 using SA_Tools;
 using SonicRetro.SAModel.Direct3D;
 using SonicRetro.SAModel.Direct3D.TextureSystem;
+using System.Linq;
 
 using SonicRetro.SAModel.SAEditorCommon;
 using SonicRetro.SAModel.SAEditorCommon.DataTypes;
@@ -2516,7 +2517,8 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					objstream.WriteLine("mtllib " + Path.GetFileNameWithoutExtension(a.FileName) + ".mtl");
 
-					int stepCount = LevelData.TextureBitmaps[LevelData.leveltexs].Length + LevelData.geo.COL.Count;
+                    int levelItemsCount = LevelData.LevelItems.Count(v => mode == 0 || (mode == 1 && v.Visible) || (mode == 2 && !v.Visible));
+                    int stepCount = LevelData.TextureBitmaps[LevelData.leveltexs].Length + levelItemsCount;
 					if (LevelData.geo.Anim != null)
 						stepCount += LevelData.geo.Anim.Count;
 
@@ -2563,7 +2565,7 @@ namespace SonicRetro.SAModel.SADXLVL2
                             Direct3D.Extensions.WriteModelAsObj(objstream, LevelData.geo.COL[i].Model, materialPrefix, new MatrixStack(),
                                 ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);
 
-                            progress.Step = String.Format("Mesh {0}/{1}", i + 1, LevelData.geo.COL.Count);
+                            progress.Step = String.Format("Mesh {0}/{1}", i + 1, levelItemsCount);
                             progress.StepProgress();
                             Application.DoEvents();
                         }

--- a/SADXLVL2/MainForm.cs
+++ b/SADXLVL2/MainForm.cs
@@ -2485,22 +2485,29 @@ namespace SonicRetro.SAModel.SADXLVL2
 				}
 		}
 
+        private enum exportModes
+        {
+            all,
+            visible,
+            invisible
+        }
+
         private void allToolStripMenuItem1_Click(object sender, EventArgs e)
         {
-            exportOBJ(0);
+            exportOBJ(exportModes.all);
         }
 
         private void visibleToolStripMenuItem1_Click(object sender, EventArgs e)
         {
-            exportOBJ(1);
+            exportOBJ(exportModes.visible);
         }
 
         private void invisibleToolStripMenuItem1_Click(object sender, EventArgs e)
         {
-            exportOBJ(2);
+            exportOBJ(exportModes.invisible);
         }
 
-        private void exportOBJ(int mode)
+        private void exportOBJ(exportModes mode)
 		{
 			SaveFileDialog a = new SaveFileDialog
 			{
@@ -2517,7 +2524,7 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					objstream.WriteLine("mtllib " + Path.GetFileNameWithoutExtension(a.FileName) + ".mtl");
 
-                    int levelItemsCount = LevelData.LevelItems.Count(v => mode == 0 || (mode == 1 && v.Visible) || (mode == 2 && !v.Visible));
+                    int levelItemsCount = LevelData.LevelItems.Count(v => mode == exportModes.all || (mode == exportModes.visible && v.Visible) || (mode == exportModes.invisible && !v.Visible));
                     int stepCount = LevelData.TextureBitmaps[LevelData.leveltexs].Length + levelItemsCount;
 					if (LevelData.geo.Anim != null)
 						stepCount += LevelData.geo.Anim.Count;
@@ -2560,7 +2567,7 @@ namespace SonicRetro.SAModel.SADXLVL2
 
 					for (int i = 0; i < LevelData.geo.COL.Count; i++)
 					{
-                        if (mode == 0 || (mode == 1 && LevelData.LevelItems[i].Visible) || (mode == 2 && !LevelData.LevelItems[i].Visible))
+                        if (mode == exportModes.all || (mode == exportModes.visible && LevelData.LevelItems[i].Visible) || (mode == exportModes.invisible && !LevelData.LevelItems[i].Visible))
                         {
                             Direct3D.Extensions.WriteModelAsObj(objstream, LevelData.geo.COL[i].Model, materialPrefix, new MatrixStack(),
                                 ref totalVerts, ref totalNorms, ref totalUVs, ref errorFlag);

--- a/SADXLVL2/MainForm.designer.cs
+++ b/SADXLVL2/MainForm.designer.cs
@@ -1,0 +1,995 @@
+﻿namespace SonicRetro.SAModel.SADXLVL2
+{
+    partial class MainForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.changeLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.noneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportOBJToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.visibleToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.invisibleToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.allToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.recentProjectsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.noneToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.exitToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.clearLevelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearGeometry = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearAnimations = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearSetItems = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearCamItems = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearMissionSetItems = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolClearAll = new System.Windows.Forms.ToolStripMenuItem();
+            this.sETItemsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.findReplaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteAllOfTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.duplicateToToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.duplicateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.calculateAllBoundsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            this.preferencesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.characterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sonicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.tailsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.knucklesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.amyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.gammaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.bigToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.levelToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.visibleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.invisibleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.allToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deathZonesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.backgroundToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sETITemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cAMItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.missionSETItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.statsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.reportBugToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.panel1 = new System.Windows.Forms.UserControl();
+            this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
+            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.addToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.levelPieceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.objectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deathZoneToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cameraToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.missionObjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.cutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.deleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.pointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.propertyGrid1 = new System.Windows.Forms.PropertyGrid();
+            this.importFileDialog = new System.Windows.Forms.OpenFileDialog();
+            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.selectModeButton = new System.Windows.Forms.ToolStripButton();
+            this.moveModeButton = new System.Windows.Forms.ToolStripButton();
+            this.rotateModeButton = new System.Windows.Forms.ToolStripButton();
+            this.scaleModeButton = new System.Windows.Forms.ToolStripButton();
+            this.gizmoSpaceComboBox = new System.Windows.Forms.ToolStripComboBox();
+            this.toolBig = new System.Windows.Forms.ToolStripButton();
+            this.toolGamma = new System.Windows.Forms.ToolStripButton();
+            this.toolAmy = new System.Windows.Forms.ToolStripButton();
+            this.toolKnuckles = new System.Windows.Forms.ToolStripButton();
+            this.toolTails = new System.Windows.Forms.ToolStripButton();
+            this.toolSonic = new System.Windows.Forms.ToolStripButton();
+            this.menuStrip1.SuspendLayout();
+            this.contextMenuStrip1.SuspendLayout();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.toolStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // menuStrip1
+            // 
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem,
+            this.editToolStripMenuItem,
+            this.viewToolStripMenuItem,
+            this.helpToolStripMenuItem});
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Size = new System.Drawing.Size(584, 24);
+            this.menuStrip1.TabIndex = 0;
+            this.menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.openToolStripMenuItem,
+            this.changeLevelToolStripMenuItem,
+            this.saveToolStripMenuItem,
+            this.importToolStripMenuItem,
+            this.exportOBJToolStripMenuItem,
+            this.recentProjectsToolStripMenuItem,
+            this.toolStripSeparator1,
+            this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Text = "&File";
+            // 
+            // openToolStripMenuItem
+            // 
+            this.openToolStripMenuItem.Name = "openToolStripMenuItem";
+            this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.openToolStripMenuItem.Text = "&Open...";
+            this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
+            // 
+            // changeLevelToolStripMenuItem
+            // 
+            this.changeLevelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.noneToolStripMenuItem});
+            this.changeLevelToolStripMenuItem.Enabled = false;
+            this.changeLevelToolStripMenuItem.Name = "changeLevelToolStripMenuItem";
+            this.changeLevelToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.changeLevelToolStripMenuItem.Text = "&Change Level...";
+            this.changeLevelToolStripMenuItem.Click += new System.EventHandler(this.changeLevelToolStripMenuItem_Click);
+            // 
+            // noneToolStripMenuItem
+            // 
+            this.noneToolStripMenuItem.Enabled = false;
+            this.noneToolStripMenuItem.Name = "noneToolStripMenuItem";
+            this.noneToolStripMenuItem.Size = new System.Drawing.Size(109, 22);
+            this.noneToolStripMenuItem.Text = "(none)";
+            // 
+            // saveToolStripMenuItem
+            // 
+            this.saveToolStripMenuItem.Enabled = false;
+            this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.saveToolStripMenuItem.Text = "&Save";
+            this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
+            // 
+            // importToolStripMenuItem
+            // 
+            this.importToolStripMenuItem.Enabled = false;
+            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.importToolStripMenuItem.Text = "&Import";
+            this.importToolStripMenuItem.Click += new System.EventHandler(this.importToolStripMenuItem_Click);
+            // 
+            // exportOBJToolStripMenuItem
+            // 
+            this.exportOBJToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.visibleToolStripMenuItem1,
+            this.invisibleToolStripMenuItem1,
+            this.allToolStripMenuItem1});
+            this.exportOBJToolStripMenuItem.Enabled = false;
+            this.exportOBJToolStripMenuItem.Name = "exportOBJToolStripMenuItem";
+            this.exportOBJToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.exportOBJToolStripMenuItem.Text = "&Export OBJ";
+            // 
+            // visibleToolStripMenuItem1
+            // 
+            this.visibleToolStripMenuItem1.Name = "visibleToolStripMenuItem1";
+            this.visibleToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.visibleToolStripMenuItem1.Text = "Visible";
+            this.visibleToolStripMenuItem1.Click += new System.EventHandler(this.visibleToolStripMenuItem1_Click);
+            // 
+            // invisibleToolStripMenuItem1
+            // 
+            this.invisibleToolStripMenuItem1.Name = "invisibleToolStripMenuItem1";
+            this.invisibleToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.invisibleToolStripMenuItem1.Text = "Invisible";
+            this.invisibleToolStripMenuItem1.Click += new System.EventHandler(this.invisibleToolStripMenuItem1_Click);
+            // 
+            // allToolStripMenuItem1
+            // 
+            this.allToolStripMenuItem1.Name = "allToolStripMenuItem1";
+            this.allToolStripMenuItem1.Size = new System.Drawing.Size(152, 22);
+            this.allToolStripMenuItem1.Text = "All";
+            this.allToolStripMenuItem1.Click += new System.EventHandler(this.allToolStripMenuItem1_Click);
+            // 
+            // recentProjectsToolStripMenuItem
+            // 
+            this.recentProjectsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.noneToolStripMenuItem2});
+            this.recentProjectsToolStripMenuItem.Name = "recentProjectsToolStripMenuItem";
+            this.recentProjectsToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.recentProjectsToolStripMenuItem.Text = "&Recent Projects";
+            this.recentProjectsToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.recentProjectsToolStripMenuItem_DropDownItemClicked);
+            this.recentProjectsToolStripMenuItem.Click += new System.EventHandler(this.recentProjectsToolStripMenuItem_Click);
+            // 
+            // noneToolStripMenuItem2
+            // 
+            this.noneToolStripMenuItem2.Enabled = false;
+            this.noneToolStripMenuItem2.Name = "noneToolStripMenuItem2";
+            this.noneToolStripMenuItem2.Size = new System.Drawing.Size(109, 22);
+            this.noneToolStripMenuItem2.Text = "(none)";
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(152, 6);
+            // 
+            // exitToolStripMenuItem
+            // 
+            this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
+            this.exitToolStripMenuItem.Text = "E&xit";
+            this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
+            // 
+            // editToolStripMenuItem
+            // 
+            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.clearLevelToolStripMenuItem,
+            this.sETItemsToolStripMenuItem1,
+            this.duplicateToolStripMenuItem,
+            this.calculateAllBoundsToolStripMenuItem,
+            this.toolStripMenuItem1,
+            this.preferencesToolStripMenuItem});
+            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Text = "&Edit";
+            // 
+            // clearLevelToolStripMenuItem
+            // 
+            this.clearLevelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolClearGeometry,
+            this.toolClearAnimations,
+            this.toolClearSetItems,
+            this.toolClearCamItems,
+            this.toolClearMissionSetItems,
+            this.toolClearAll});
+            this.clearLevelToolStripMenuItem.Name = "clearLevelToolStripMenuItem";
+            this.clearLevelToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
+            this.clearLevelToolStripMenuItem.Text = "Clear Level";
+            // 
+            // toolClearGeometry
+            // 
+            this.toolClearGeometry.Name = "toolClearGeometry";
+            this.toolClearGeometry.Size = new System.Drawing.Size(169, 22);
+            this.toolClearGeometry.Text = "Geometry";
+            this.toolClearGeometry.Click += new System.EventHandler(this.toolClearGeometry_Click);
+            // 
+            // toolClearAnimations
+            // 
+            this.toolClearAnimations.Name = "toolClearAnimations";
+            this.toolClearAnimations.Size = new System.Drawing.Size(169, 22);
+            this.toolClearAnimations.Text = "Animations";
+            this.toolClearAnimations.Click += new System.EventHandler(this.toolClearAnimations_Click);
+            // 
+            // toolClearSetItems
+            // 
+            this.toolClearSetItems.Name = "toolClearSetItems";
+            this.toolClearSetItems.Size = new System.Drawing.Size(169, 22);
+            this.toolClearSetItems.Text = "SET Items";
+            this.toolClearSetItems.Click += new System.EventHandler(this.toolClearSetItems_Click);
+            // 
+            // toolClearCamItems
+            // 
+            this.toolClearCamItems.Name = "toolClearCamItems";
+            this.toolClearCamItems.Size = new System.Drawing.Size(169, 22);
+            this.toolClearCamItems.Text = "CAM Items";
+            this.toolClearCamItems.Click += new System.EventHandler(this.toolClearCamItems_Click);
+            // 
+            // toolClearMissionSetItems
+            // 
+            this.toolClearMissionSetItems.Name = "toolClearMissionSetItems";
+            this.toolClearMissionSetItems.Size = new System.Drawing.Size(169, 22);
+            this.toolClearMissionSetItems.Text = "Mission SET Items";
+            this.toolClearMissionSetItems.Click += new System.EventHandler(this.toolClearMissionSetItems_Click);
+            // 
+            // toolClearAll
+            // 
+            this.toolClearAll.Name = "toolClearAll";
+            this.toolClearAll.Size = new System.Drawing.Size(169, 22);
+            this.toolClearAll.Text = "All";
+            this.toolClearAll.Click += new System.EventHandler(this.toolClearAll_Click);
+            // 
+            // sETItemsToolStripMenuItem1
+            // 
+            this.sETItemsToolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.findReplaceToolStripMenuItem,
+            this.deleteAllOfTypeToolStripMenuItem,
+            this.duplicateToToolStripMenuItem});
+            this.sETItemsToolStripMenuItem1.Enabled = false;
+            this.sETItemsToolStripMenuItem1.Name = "sETItemsToolStripMenuItem1";
+            this.sETItemsToolStripMenuItem1.Size = new System.Drawing.Size(183, 22);
+            this.sETItemsToolStripMenuItem1.Text = "SET Items";
+            // 
+            // findReplaceToolStripMenuItem
+            // 
+            this.findReplaceToolStripMenuItem.Name = "findReplaceToolStripMenuItem";
+            this.findReplaceToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.findReplaceToolStripMenuItem.Text = "Find/Replace";
+            this.findReplaceToolStripMenuItem.Click += new System.EventHandler(this.findReplaceToolStripMenuItem_Click);
+            // 
+            // deleteAllOfTypeToolStripMenuItem
+            // 
+            this.deleteAllOfTypeToolStripMenuItem.Name = "deleteAllOfTypeToolStripMenuItem";
+            this.deleteAllOfTypeToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.deleteAllOfTypeToolStripMenuItem.Text = "Delete All of Type";
+            this.deleteAllOfTypeToolStripMenuItem.Click += new System.EventHandler(this.deleteAllOfTypeToolStripMenuItem_Click);
+            // 
+            // duplicateToToolStripMenuItem
+            // 
+            this.duplicateToToolStripMenuItem.Name = "duplicateToToolStripMenuItem";
+            this.duplicateToToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.duplicateToToolStripMenuItem.Text = "Duplicate &To";
+            this.duplicateToToolStripMenuItem.Click += new System.EventHandler(this.duplicateToToolStripMenuItem_Click);
+            // 
+            // duplicateToolStripMenuItem
+            // 
+            this.duplicateToolStripMenuItem.Enabled = false;
+            this.duplicateToolStripMenuItem.Name = "duplicateToolStripMenuItem";
+            this.duplicateToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D)));
+            this.duplicateToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
+            this.duplicateToolStripMenuItem.Text = "&Duplicate";
+            this.duplicateToolStripMenuItem.Click += new System.EventHandler(this.duplicateToolStripMenuItem_Click);
+            // 
+            // calculateAllBoundsToolStripMenuItem
+            // 
+            this.calculateAllBoundsToolStripMenuItem.Enabled = false;
+            this.calculateAllBoundsToolStripMenuItem.Name = "calculateAllBoundsToolStripMenuItem";
+            this.calculateAllBoundsToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
+            this.calculateAllBoundsToolStripMenuItem.Text = "Calculate All Bounds";
+            this.calculateAllBoundsToolStripMenuItem.Click += new System.EventHandler(this.calculateAllBoundsToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(180, 6);
+            // 
+            // preferencesToolStripMenuItem
+            // 
+            this.preferencesToolStripMenuItem.Name = "preferencesToolStripMenuItem";
+            this.preferencesToolStripMenuItem.Size = new System.Drawing.Size(183, 22);
+            this.preferencesToolStripMenuItem.Text = "&Preferences";
+            this.preferencesToolStripMenuItem.Click += new System.EventHandler(this.preferencesToolStripMenuItem_Click);
+            // 
+            // viewToolStripMenuItem
+            // 
+            this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.characterToolStripMenuItem,
+            this.levelToolStripMenuItem,
+            this.deathZonesToolStripMenuItem,
+            this.backgroundToolStripMenuItem,
+            this.sETITemsToolStripMenuItem,
+            this.cAMItemsToolStripMenuItem,
+            this.missionSETItemsToolStripMenuItem,
+            this.splinesToolStripMenuItem,
+            this.statsToolStripMenuItem});
+            this.viewToolStripMenuItem.Enabled = false;
+            this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.viewToolStripMenuItem.Text = "&View";
+            // 
+            // characterToolStripMenuItem
+            // 
+            this.characterToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.sonicToolStripMenuItem,
+            this.tailsToolStripMenuItem,
+            this.knucklesToolStripMenuItem,
+            this.amyToolStripMenuItem,
+            this.gammaToolStripMenuItem,
+            this.bigToolStripMenuItem});
+            this.characterToolStripMenuItem.Name = "characterToolStripMenuItem";
+            this.characterToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.characterToolStripMenuItem.Text = "&Character";
+            this.characterToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.characterToolStripMenuItem_DropDownItemClicked);
+            // 
+            // sonicToolStripMenuItem
+            // 
+            this.sonicToolStripMenuItem.Checked = true;
+            this.sonicToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.sonicToolStripMenuItem.Name = "sonicToolStripMenuItem";
+            this.sonicToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.sonicToolStripMenuItem.Text = "&Sonic";
+            // 
+            // tailsToolStripMenuItem
+            // 
+            this.tailsToolStripMenuItem.Name = "tailsToolStripMenuItem";
+            this.tailsToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.tailsToolStripMenuItem.Text = "&Tails";
+            // 
+            // knucklesToolStripMenuItem
+            // 
+            this.knucklesToolStripMenuItem.Name = "knucklesToolStripMenuItem";
+            this.knucklesToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.knucklesToolStripMenuItem.Text = "&Knuckles";
+            // 
+            // amyToolStripMenuItem
+            // 
+            this.amyToolStripMenuItem.Name = "amyToolStripMenuItem";
+            this.amyToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.amyToolStripMenuItem.Text = "&Amy";
+            // 
+            // gammaToolStripMenuItem
+            // 
+            this.gammaToolStripMenuItem.Name = "gammaToolStripMenuItem";
+            this.gammaToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.gammaToolStripMenuItem.Text = "&Gamma";
+            // 
+            // bigToolStripMenuItem
+            // 
+            this.bigToolStripMenuItem.Name = "bigToolStripMenuItem";
+            this.bigToolStripMenuItem.Size = new System.Drawing.Size(121, 22);
+            this.bigToolStripMenuItem.Text = "&Big";
+            // 
+            // levelToolStripMenuItem
+            // 
+            this.levelToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.visibleToolStripMenuItem,
+            this.invisibleToolStripMenuItem,
+            this.allToolStripMenuItem});
+            this.levelToolStripMenuItem.Name = "levelToolStripMenuItem";
+            this.levelToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.levelToolStripMenuItem.Text = "&Level";
+            this.levelToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.levelToolStripMenuItem_DropDownItemClicked);
+            // 
+            // visibleToolStripMenuItem
+            // 
+            this.visibleToolStripMenuItem.Checked = true;
+            this.visibleToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.visibleToolStripMenuItem.Name = "visibleToolStripMenuItem";
+            this.visibleToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.visibleToolStripMenuItem.Text = "&Visible";
+            // 
+            // invisibleToolStripMenuItem
+            // 
+            this.invisibleToolStripMenuItem.Name = "invisibleToolStripMenuItem";
+            this.invisibleToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.invisibleToolStripMenuItem.Text = "&Invisible";
+            // 
+            // allToolStripMenuItem
+            // 
+            this.allToolStripMenuItem.Name = "allToolStripMenuItem";
+            this.allToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
+            this.allToolStripMenuItem.Text = "&All";
+            // 
+            // deathZonesToolStripMenuItem
+            // 
+            this.deathZonesToolStripMenuItem.CheckOnClick = true;
+            this.deathZonesToolStripMenuItem.Name = "deathZonesToolStripMenuItem";
+            this.deathZonesToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.deathZonesToolStripMenuItem.Text = "&Death Zones";
+            this.deathZonesToolStripMenuItem.Click += new System.EventHandler(this.deathZonesToolStripMenuItem_Click);
+            // 
+            // backgroundToolStripMenuItem
+            // 
+            this.backgroundToolStripMenuItem.Checked = true;
+            this.backgroundToolStripMenuItem.CheckOnClick = true;
+            this.backgroundToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.backgroundToolStripMenuItem.Name = "backgroundToolStripMenuItem";
+            this.backgroundToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.backgroundToolStripMenuItem.Text = "&Background";
+            this.backgroundToolStripMenuItem.Click += new System.EventHandler(this.backgroundToolStripMenuItem_Click);
+            // 
+            // sETITemsToolStripMenuItem
+            // 
+            this.sETITemsToolStripMenuItem.Checked = true;
+            this.sETITemsToolStripMenuItem.CheckOnClick = true;
+            this.sETITemsToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.sETITemsToolStripMenuItem.Name = "sETITemsToolStripMenuItem";
+            this.sETITemsToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.sETITemsToolStripMenuItem.Text = "SET Items";
+            this.sETITemsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.sETITemsToolStripMenuItem_CheckedChanged);
+            // 
+            // cAMItemsToolStripMenuItem
+            // 
+            this.cAMItemsToolStripMenuItem.CheckOnClick = true;
+            this.cAMItemsToolStripMenuItem.Name = "cAMItemsToolStripMenuItem";
+            this.cAMItemsToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.cAMItemsToolStripMenuItem.Text = "CAM Items";
+            this.cAMItemsToolStripMenuItem.CheckedChanged += new System.EventHandler(this.cAMItemsToolStripMenuItem_CheckedChanged);
+            // 
+            // missionSETItemsToolStripMenuItem
+            // 
+            this.missionSETItemsToolStripMenuItem.CheckOnClick = true;
+            this.missionSETItemsToolStripMenuItem.Name = "missionSETItemsToolStripMenuItem";
+            this.missionSETItemsToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.missionSETItemsToolStripMenuItem.Text = "Mission SET Items";
+            this.missionSETItemsToolStripMenuItem.Click += new System.EventHandler(this.sETITemsToolStripMenuItem_CheckedChanged);
+            // 
+            // splinesToolStripMenuItem
+            // 
+            this.splinesToolStripMenuItem.Checked = true;
+            this.splinesToolStripMenuItem.CheckOnClick = true;
+            this.splinesToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.splinesToolStripMenuItem.Name = "splinesToolStripMenuItem";
+            this.splinesToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.splinesToolStripMenuItem.Text = "Splines";
+            this.splinesToolStripMenuItem.CheckedChanged += new System.EventHandler(this.splinesToolStripMenuItem_CheckedChanged);
+            // 
+            // statsToolStripMenuItem
+            // 
+            this.statsToolStripMenuItem.Name = "statsToolStripMenuItem";
+            this.statsToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.statsToolStripMenuItem.Text = "Stats";
+            this.statsToolStripMenuItem.Click += new System.EventHandler(this.statsToolStripMenuItem_Click);
+            // 
+            // helpToolStripMenuItem
+            // 
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.reportBugToolStripMenuItem});
+            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Text = "&Help";
+            // 
+            // reportBugToolStripMenuItem
+            // 
+            this.reportBugToolStripMenuItem.Name = "reportBugToolStripMenuItem";
+            this.reportBugToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
+            this.reportBugToolStripMenuItem.Text = "Report &Bug";
+            this.reportBugToolStripMenuItem.Click += new System.EventHandler(this.reportBugToolStripMenuItem_Click);
+            // 
+            // panel1
+            // 
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(318, 512);
+            this.panel1.TabIndex = 1;
+            this.panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.panel1_Paint);
+            this.panel1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.panel1_KeyDown);
+            this.panel1.KeyUp += new System.Windows.Forms.KeyEventHandler(this.panel1_KeyUp);
+            this.panel1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.panel1_MouseDown);
+            this.panel1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.Panel1_MouseMove);
+            this.panel1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panel1_MouseUp);
+            this.panel1.PreviewKeyDown += new System.Windows.Forms.PreviewKeyDownEventHandler(this.panel1_PreviewKeyDown);
+            // 
+            // backgroundWorker1
+            // 
+            this.backgroundWorker1.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker1_DoWork);
+            this.backgroundWorker1.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorker1_RunWorkerCompleted);
+            // 
+            // contextMenuStrip1
+            // 
+            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.addToolStripMenuItem,
+            this.cutToolStripMenuItem,
+            this.copyToolStripMenuItem,
+            this.pasteToolStripMenuItem,
+            this.deleteToolStripMenuItem,
+            this.toolStripMenuItem2,
+            this.pointToolStripMenuItem});
+            this.contextMenuStrip1.Name = "contextMenuStrip1";
+            this.contextMenuStrip1.Size = new System.Drawing.Size(108, 142);
+            // 
+            // addToolStripMenuItem
+            // 
+            this.addToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.levelPieceToolStripMenuItem,
+            this.objectToolStripMenuItem,
+            this.deathZoneToolStripMenuItem,
+            this.cameraToolStripMenuItem,
+            this.missionObjectToolStripMenuItem});
+            this.addToolStripMenuItem.Name = "addToolStripMenuItem";
+            this.addToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.addToolStripMenuItem.Text = "&Add...";
+            // 
+            // levelPieceToolStripMenuItem
+            // 
+            this.levelPieceToolStripMenuItem.Name = "levelPieceToolStripMenuItem";
+            this.levelPieceToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.levelPieceToolStripMenuItem.Text = "&Level Piece";
+            this.levelPieceToolStripMenuItem.Click += new System.EventHandler(this.levelPieceToolStripMenuItem_Click);
+            // 
+            // objectToolStripMenuItem
+            // 
+            this.objectToolStripMenuItem.Name = "objectToolStripMenuItem";
+            this.objectToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.objectToolStripMenuItem.Text = "&Object";
+            this.objectToolStripMenuItem.Click += new System.EventHandler(this.objectToolStripMenuItem_Click);
+            // 
+            // deathZoneToolStripMenuItem
+            // 
+            this.deathZoneToolStripMenuItem.Name = "deathZoneToolStripMenuItem";
+            this.deathZoneToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.deathZoneToolStripMenuItem.Text = "&Death Zone";
+            this.deathZoneToolStripMenuItem.Click += new System.EventHandler(this.deathZoneToolStripMenuItem_Click);
+            // 
+            // cameraToolStripMenuItem
+            // 
+            this.cameraToolStripMenuItem.Name = "cameraToolStripMenuItem";
+            this.cameraToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.cameraToolStripMenuItem.Text = "&Camera";
+            this.cameraToolStripMenuItem.Click += new System.EventHandler(this.cameraToolStripMenuItem_Click);
+            // 
+            // missionObjectToolStripMenuItem
+            // 
+            this.missionObjectToolStripMenuItem.Name = "missionObjectToolStripMenuItem";
+            this.missionObjectToolStripMenuItem.Size = new System.Drawing.Size(153, 22);
+            this.missionObjectToolStripMenuItem.Text = "&Mission Object";
+            this.missionObjectToolStripMenuItem.Click += new System.EventHandler(this.missionObjectToolStripMenuItem_Click);
+            // 
+            // cutToolStripMenuItem
+            // 
+            this.cutToolStripMenuItem.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.cut;
+            this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.cutToolStripMenuItem.Text = "Cu&t";
+            this.cutToolStripMenuItem.Click += new System.EventHandler(this.cutToolStripMenuItem_Click);
+            // 
+            // copyToolStripMenuItem
+            // 
+            this.copyToolStripMenuItem.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.copy;
+            this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.copyToolStripMenuItem.Text = "&Copy";
+            this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
+            // 
+            // pasteToolStripMenuItem
+            // 
+            this.pasteToolStripMenuItem.Enabled = false;
+            this.pasteToolStripMenuItem.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.paste;
+            this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.pasteToolStripMenuItem.Text = "&Paste";
+            this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
+            // 
+            // deleteToolStripMenuItem
+            // 
+            this.deleteToolStripMenuItem.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.delete;
+            this.deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
+            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.deleteToolStripMenuItem.Text = "&Delete";
+            this.deleteToolStripMenuItem.Click += new System.EventHandler(this.deleteToolStripMenuItem_Click);
+            // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(104, 6);
+            // 
+            // pointToolStripMenuItem
+            // 
+            this.pointToolStripMenuItem.Name = "pointToolStripMenuItem";
+            this.pointToolStripMenuItem.Size = new System.Drawing.Size(107, 22);
+            this.pointToolStripMenuItem.Text = "Point";
+            this.pointToolStripMenuItem.Click += new System.EventHandler(this.pointToolStripMenuItem_Click);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 52);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.panel1);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.propertyGrid1);
+            this.splitContainer1.Size = new System.Drawing.Size(584, 512);
+            this.splitContainer1.SplitterDistance = 318;
+            this.splitContainer1.TabIndex = 2;
+            // 
+            // propertyGrid1
+            // 
+            this.propertyGrid1.CategoryForeColor = System.Drawing.SystemColors.InactiveCaptionText;
+            this.propertyGrid1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.propertyGrid1.LineColor = System.Drawing.SystemColors.ControlDark;
+            this.propertyGrid1.Location = new System.Drawing.Point(0, 0);
+            this.propertyGrid1.Margin = new System.Windows.Forms.Padding(0);
+            this.propertyGrid1.Name = "propertyGrid1";
+            this.propertyGrid1.PropertySort = System.Windows.Forms.PropertySort.Alphabetical;
+            this.propertyGrid1.Size = new System.Drawing.Size(262, 512);
+            this.propertyGrid1.TabIndex = 13;
+            this.propertyGrid1.ToolbarVisible = false;
+            this.propertyGrid1.PropertyValueChanged += new System.Windows.Forms.PropertyValueChangedEventHandler(this.propertyGrid1_PropertyValueChanged);
+            // 
+            // importFileDialog
+            // 
+            this.importFileDialog.FileName = "file";
+            this.importFileDialog.Filter = "*.OBJ Format|*.obj;*.objf|NodeTable|*.txt";
+            this.importFileDialog.Multiselect = true;
+            this.importFileDialog.RestoreDirectory = true;
+            this.importFileDialog.Title = "Select a file to import.";
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.Enabled = false;
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.selectModeButton,
+            this.moveModeButton,
+            this.rotateModeButton,
+            this.scaleModeButton,
+            this.gizmoSpaceComboBox,
+            this.toolBig,
+            this.toolGamma,
+            this.toolAmy,
+            this.toolKnuckles,
+            this.toolTails,
+            this.toolSonic});
+            this.toolStrip1.Location = new System.Drawing.Point(0, 24);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(584, 25);
+            this.toolStrip1.TabIndex = 3;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // selectModeButton
+            // 
+            this.selectModeButton.Checked = true;
+            this.selectModeButton.CheckOnClick = true;
+            this.selectModeButton.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.selectModeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.selectModeButton.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.SelectIcon;
+            this.selectModeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.selectModeButton.Name = "selectModeButton";
+            this.selectModeButton.Size = new System.Drawing.Size(23, 22);
+            this.selectModeButton.Text = "toolStripButton1";
+            this.selectModeButton.ToolTipText = "Select Item Mode";
+            this.selectModeButton.Click += new System.EventHandler(this.selectModeButton_Click);
+            // 
+            // moveModeButton
+            // 
+            this.moveModeButton.CheckOnClick = true;
+            this.moveModeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.moveModeButton.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.MoveIcon;
+            this.moveModeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.moveModeButton.Name = "moveModeButton";
+            this.moveModeButton.Size = new System.Drawing.Size(23, 22);
+            this.moveModeButton.Text = "toolStripButton1";
+            this.moveModeButton.ToolTipText = "Move Item Mode";
+            this.moveModeButton.Click += new System.EventHandler(this.moveModeButton_Click);
+            // 
+            // rotateModeButton
+            // 
+            this.rotateModeButton.CheckOnClick = true;
+            this.rotateModeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.rotateModeButton.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.RotateIcon;
+            this.rotateModeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.rotateModeButton.Name = "rotateModeButton";
+            this.rotateModeButton.Size = new System.Drawing.Size(23, 22);
+            this.rotateModeButton.Text = "toolStripButton1";
+            this.rotateModeButton.ToolTipText = "Rotate Item Mode";
+            this.rotateModeButton.Click += new System.EventHandler(this.rotateModeButton_Click);
+            // 
+            // scaleModeButton
+            // 
+            this.scaleModeButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.scaleModeButton.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.ScaleIcon;
+            this.scaleModeButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.scaleModeButton.Name = "scaleModeButton";
+            this.scaleModeButton.Size = new System.Drawing.Size(23, 22);
+            this.scaleModeButton.Text = "toolStripButton1";
+            this.scaleModeButton.ToolTipText = "Scale Mode";
+            this.scaleModeButton.Click += new System.EventHandler(this.scaleModeButton_Click);
+            // 
+            // gizmoSpaceComboBox
+            // 
+            this.gizmoSpaceComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.gizmoSpaceComboBox.Items.AddRange(new object[] {
+            "Global",
+            "Local"});
+            this.gizmoSpaceComboBox.Name = "gizmoSpaceComboBox";
+            this.gizmoSpaceComboBox.Size = new System.Drawing.Size(121, 25);
+            this.gizmoSpaceComboBox.DropDownClosed += new System.EventHandler(this.gizmoSpaceComboBox_DropDownClosed);
+            // 
+            // toolBig
+            // 
+            this.toolBig.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolBig.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolBig.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zankib;
+            this.toolBig.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolBig.Name = "toolBig";
+            this.toolBig.Size = new System.Drawing.Size(23, 22);
+            this.toolBig.Text = "B";
+            this.toolBig.ToolTipText = "Switch to Big\'s item layout";
+            this.toolBig.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // toolGamma
+            // 
+            this.toolGamma.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolGamma.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolGamma.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zanki_e;
+            this.toolGamma.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolGamma.Name = "toolGamma";
+            this.toolGamma.Size = new System.Drawing.Size(23, 22);
+            this.toolGamma.Text = "E";
+            this.toolGamma.ToolTipText = "Switch to Gamma\'s item layout";
+            this.toolGamma.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // toolAmy
+            // 
+            this.toolAmy.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolAmy.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolAmy.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zanki_a;
+            this.toolAmy.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolAmy.Name = "toolAmy";
+            this.toolAmy.Size = new System.Drawing.Size(23, 22);
+            this.toolAmy.Text = "A";
+            this.toolAmy.ToolTipText = "Switch to Amy\'s item layout";
+            this.toolAmy.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // toolKnuckles
+            // 
+            this.toolKnuckles.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolKnuckles.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolKnuckles.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zanki_k;
+            this.toolKnuckles.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolKnuckles.Name = "toolKnuckles";
+            this.toolKnuckles.Size = new System.Drawing.Size(23, 22);
+            this.toolKnuckles.Text = "K";
+            this.toolKnuckles.ToolTipText = "Switch to Knuckles\'s item layout";
+            this.toolKnuckles.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // toolTails
+            // 
+            this.toolTails.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolTails.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolTails.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zanki_t;
+            this.toolTails.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolTails.Name = "toolTails";
+            this.toolTails.Size = new System.Drawing.Size(23, 22);
+            this.toolTails.Text = "M";
+            this.toolTails.ToolTipText = "Switch to Tails\'s item layout";
+            this.toolTails.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // toolSonic
+            // 
+            this.toolSonic.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolSonic.Checked = true;
+            this.toolSonic.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.toolSonic.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            this.toolSonic.Image = global::SonicRetro.SAModel.SADXLVL2.Properties.Resources.hyoji_zanki_s;
+            this.toolSonic.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolSonic.Name = "toolSonic";
+            this.toolSonic.Size = new System.Drawing.Size(23, 22);
+            this.toolSonic.Text = "S";
+            this.toolSonic.ToolTipText = "Switch to Sonic\'s item layout";
+            this.toolSonic.Click += new System.EventHandler(this.onClickCharacterButton);
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 564);
+            this.Controls.Add(this.toolStrip1);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.menuStrip1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
+            this.MainMenuStrip = this.menuStrip1;
+            this.Name = "MainForm";
+            this.Text = "SADXLVL2";
+            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
+            this.Load += new System.EventHandler(this.MainForm_Load);
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            this.contextMenuStrip1.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.ResumeLayout(false);
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.MenuStrip menuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem changeLevelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exitToolStripMenuItem;
+        private System.Windows.Forms.UserControl panel1;
+        private System.Windows.Forms.ToolStripMenuItem noneToolStripMenuItem;
+        private System.ComponentModel.BackgroundWorker backgroundWorker1;
+        private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem cutToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem copyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem pasteToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deleteToolStripMenuItem;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem viewToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem characterToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sonicToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem tailsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem knucklesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem amyToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem gammaToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem bigToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem levelToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem visibleToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem invisibleToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem allToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem addToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem levelPieceToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem objectToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem exportOBJToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deathZonesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem deathZoneToolStripMenuItem;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        internal System.Windows.Forms.PropertyGrid propertyGrid1;
+        private System.Windows.Forms.ToolStripMenuItem backgroundToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem recentProjectsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem reportBugToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem clearLevelToolStripMenuItem;
+        private System.Windows.Forms.OpenFileDialog importFileDialog;
+        private System.Windows.Forms.ToolStripMenuItem importToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem statsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sETITemsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem sETItemsToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem findReplaceToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem duplicateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem preferencesToolStripMenuItem;
+        private System.Windows.Forms.ToolStrip toolStrip1;
+        private System.Windows.Forms.ToolStripButton selectModeButton;
+        private System.Windows.Forms.ToolStripButton moveModeButton;
+        private System.Windows.Forms.ToolStripButton rotateModeButton;
+        private System.Windows.Forms.ToolStripComboBox gizmoSpaceComboBox;
+        private System.Windows.Forms.ToolStripMenuItem cAMItemsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem cameraToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton scaleModeButton;
+		private System.Windows.Forms.ToolStripMenuItem splinesToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem deleteAllOfTypeToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem duplicateToToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem noneToolStripMenuItem2;
+		private System.Windows.Forms.ToolStripButton toolGamma;
+		private System.Windows.Forms.ToolStripButton toolBig;
+		private System.Windows.Forms.ToolStripButton toolAmy;
+		private System.Windows.Forms.ToolStripButton toolKnuckles;
+		private System.Windows.Forms.ToolStripButton toolTails;
+		private System.Windows.Forms.ToolStripButton toolSonic;
+		private System.Windows.Forms.ToolStripMenuItem toolClearGeometry;
+		private System.Windows.Forms.ToolStripMenuItem toolClearAnimations;
+		private System.Windows.Forms.ToolStripMenuItem toolClearSetItems;
+		private System.Windows.Forms.ToolStripMenuItem toolClearAll;
+		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem1;
+		private System.Windows.Forms.ToolStripMenuItem toolClearCamItems;
+		private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+		private System.Windows.Forms.ToolStripMenuItem pointToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem calculateAllBoundsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem missionSETItemsToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem missionObjectToolStripMenuItem;
+		private System.Windows.Forms.ToolStripMenuItem toolClearMissionSetItems;
+        private System.Windows.Forms.ToolStripMenuItem visibleToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem invisibleToolStripMenuItem1;
+        private System.Windows.Forms.ToolStripMenuItem allToolStripMenuItem1;
+    }
+}
+


### PR DESCRIPTION
With that small modification, you can choose to export visible, invisible or all level items. The progression bar and text adapt to the number of level items you're actually exporting, instead of all the items in the level.