### PR TITLE
Collision rotation fix

### DIFF
--- a/Libraries/SAEditorCommon/DataTypes/StartPosItem.cs
+++ b/Libraries/SAEditorCommon/DataTypes/StartPosItem.cs
@@ -83,7 +83,7 @@ namespace SAModel.SAEditorCommon.DataTypes
 			transform.Push();
 			transform.NJTranslate(0, offset, 0);
 			transform.NJTranslate(Position);
-			transform.NJRotateY(YRotation);
+			transform.NJRotateY(-0x8000 - YRotation);
 			return Model.CheckHit(Near, Far, Viewport, Projection, View, transform, Meshes);
 		}
 


### PR DESCRIPTION
Collision rotation did not match the visual rotation, fix was to apply matching rotation to both. This makes interacting with objects when spawning into Casinopolis Act 1 tedious, because the camera was mostly pointed at an invisible statue of Sonic. 