### PR TITLE
Rework nja export for ginja models

### DIFF
--- a/Libraries/SAModel/GC/GCAttach.cs
+++ b/Libraries/SAModel/GC/GCAttach.cs
@@ -809,37 +809,37 @@ namespace SAModel.GC
 		{
 			if (!labels.Contains(VertexName))
 			{
-				writer.WriteLine($"VLIST      {VertexName}[]");
-				writer.WriteLine($"START{Environment.NewLine}");
-				
 				foreach (var item in VertexData)
 				{
 					item.ToNJA(writer);
 				}
+
+				writer.WriteLine($"GJARRAY      {VertexName}[]");
+				writer.WriteLine($"START{Environment.NewLine}");
 
 				foreach (var item in VertexData)
 				{
 					item.RefToNJA(writer);
 				}
 
-				writer.WriteLine("\tVertAttr     NULL,");
-				writer.WriteLine("\tElementSize  0,");
-				writer.WriteLine("\tPoints       0,");
-				writer.WriteLine("\tType         NULL,");
-				writer.WriteLine("\tName         NULL,");
-				writer.WriteLine("\tCheckSize    0,");
+				writer.WriteLine("ATTRSTART");
+				writer.WriteLine($"GjId         GJ_VA_NULL,");
+				writer.WriteLine($"ATTREND{Environment.NewLine}");
+
 				writer.Write($"END{Environment.NewLine}{Environment.NewLine}");
 			}
 
+			var indexFlags = GCIndexAttributeFlags.HasPosition;
+
 			if (OpaqueMeshes.Count != 0 && !labels.Contains(OpaqueMeshName))
 			{
-				writer.WriteLine($"OPLIST      {OpaqueMeshName}[]");
-				writer.WriteLine($"START{Environment.NewLine}");
-				
 				foreach (var item in OpaqueMeshes)
 				{
-					item.ToNJA(writer);
+					item.ToNJA(writer, ref indexFlags);
 				}
+
+				writer.WriteLine($"GJMESHSET     {OpaqueMeshName}[]");
+				writer.WriteLine($"START{Environment.NewLine}");
 
 				foreach (var item in OpaqueMeshes)
 				{
@@ -851,14 +851,14 @@ namespace SAModel.GC
 
 			if (TranslucentMeshes.Count != 0 && !labels.Contains(TranslucentMeshName))
 			{
-				writer.WriteLine($"APLIST      {TranslucentMeshName}[]");
-				writer.WriteLine($"START{Environment.NewLine}");
-				
 				foreach (var item in TranslucentMeshes)
 				{
-					item.ToNJA(writer);
+					item.ToNJA(writer, ref indexFlags);
 				}
 
+				writer.WriteLine($"GJMESHSET    {TranslucentMeshName}[]");
+				writer.WriteLine($"START{Environment.NewLine}");
+				
 				foreach (var item in TranslucentMeshes)
 				{
 					item.RefToNJA(writer);
@@ -867,30 +867,31 @@ namespace SAModel.GC
 				writer.Write($"END{Environment.NewLine}{Environment.NewLine}");
 			}
 
-			writer.WriteLine($"GINJAMODEL  {Name}[]");
+			writer.WriteLine($"GJMODEL     {Name}[]");
 			writer.WriteLine("START");
-			writer.WriteLine($"VList       {VertexName},");
+			writer.WriteLine($"GjArray     {VertexName},");
+			writer.WriteLine("GjVlist     NULL,");
 			
 			if (OpaqueMeshes.Count != 0 && !labels.Contains(OpaqueMeshName))
 			{
-				writer.WriteLine($"OPList      {OpaqueMeshName},");
+				writer.WriteLine($"GjOMesh     {OpaqueMeshName},");
 			}
 			else
 			{
-				writer.WriteLine("OPList      NULL,");
+				writer.WriteLine("GjOMesh     NULL,");
 			}
 
 			if (TranslucentMeshes.Count != 0 && !labels.Contains(TranslucentMeshName))
 			{
-				writer.WriteLine($"APList      {TranslucentMeshName},");
+				writer.WriteLine($"GjAMesh     {TranslucentMeshName},");
 			}
 			else
 			{
-				writer.WriteLine("APList      NULL,");
+				writer.WriteLine("GjAMesh     NULL,");
 			}
 
-			writer.WriteLine($"OPNum       {OpaqueMeshes.Count},");
-			writer.WriteLine($"APNum       {TranslucentMeshes.Count},");
+			writer.WriteLine($"GjNbOMesh   {OpaqueMeshes.Count},");
+			writer.WriteLine($"GjNbAMesh   {TranslucentMeshes.Count},");
 			writer.WriteLine($"Center     {Bounds.Center.X.ToNJA()}, {Bounds.Center.Y.ToNJA()}, {Bounds.Center.Z.ToNJA()},");
 			writer.WriteLine($"Radius     {Bounds.Radius.ToNJA()},");
 			writer.Write($"END{Environment.NewLine}{Environment.NewLine}");

--- a/Libraries/SAModel/GC/GCMesh.cs
+++ b/Libraries/SAModel/GC/GCMesh.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace SAModel.GC
@@ -228,11 +229,11 @@ namespace SAModel.GC
 		}
 
 		// WIP
-		public void ToNJA(TextWriter writer)
+		public void ToNJA(TextWriter writer, ref GCIndexAttributeFlags indexFlags)
 		{
 			if (Parameters != null && Parameters.Count != 0)
 			{
-				writer.WriteLine($"PARAMETER   {ParameterName}[]");
+				writer.WriteLine($"GJMATERIAL   {ParameterName}[]");
 				writer.WriteLine("START");
 				
 				foreach (var item in Parameters)
@@ -245,13 +246,37 @@ namespace SAModel.GC
 
 			if (Primitives != null)
 			{
-				writer.WriteLine($"PRIMITIVE   {PrimitiveName}[]");
+				writer.WriteLine($"GJDRAWLIST   {PrimitiveName}[]");
 				writer.WriteLine("START");
-				
+
+				var pbytes = new List<byte>();
 				foreach (var item in Primitives)
 				{
-					item.ToNJA(writer);
+					var t = IndexFlags;
+					if (t.HasValue)
+					{
+						indexFlags = t.Value;
+					}
+
+					foreach (var primitive in Primitives)
+					{
+						pbytes.AddRange(primitive.GetBytes(indexFlags));
+					}
 				}
+
+				var cb = pbytes.ToArray();
+				var dataSize = Convert.ToInt32(Math.Ceiling(decimal.Divide(cb.Length, 32)) * 32);
+				var buffSize = dataSize - cb.Length;
+				var s = new List<string>(dataSize);
+
+				s.AddRange(cb.Select(b => $"0x{b:X}"));
+
+				for (var l = 0; l < buffSize; l++)
+				{
+					s.Add("0x0");
+				}
+
+				writer.WriteLine(string.Join(", ", s.ToArray()));
 
 				writer.Write($"END{Environment.NewLine}{Environment.NewLine}");
 			}
@@ -259,27 +284,29 @@ namespace SAModel.GC
 		
 		public void RefToNJA(TextWriter writer)
 		{
+			writer.WriteLine("MESHSTART");
 			if (Parameters != null && Parameters.Count != 0)
 			{
-				writer.WriteLine($"Parameter   {ParameterName},");
+				writer.WriteLine($"GjMats        {ParameterName},");
 			}
 			else
 			{
-				writer.WriteLine($"Parameter   NULL{ParameterName},");
+				writer.WriteLine($"GjMats        NULL{ParameterName},");
 			}
 
-			writer.WriteLine($"ParamNum    {Parameters.Count},");
+			writer.WriteLine($"GjNbMat       {Parameters.Count},");
 
 			if (Primitives != null)
 			{
-				writer.WriteLine($"Primitive   {PrimitiveName},");
+				writer.WriteLine($"GjDispList    {PrimitiveName},");
 			}
 			else
 			{
-				writer.WriteLine($"Primitive   NULL{PrimitiveName},");
+				writer.WriteLine($"GjDispList    NULL{PrimitiveName},");
 			}
 
-			writer.WriteLine($"PrimNum     {_primitiveSize},");
+			writer.WriteLine($"GjSzDispList  {_primitiveSize},");
+			writer.Write($"MESHEND{Environment.NewLine}{Environment.NewLine}");
 		}
 
 		/// <summary>

--- a/Libraries/SAModel/GC/GCParameter.cs
+++ b/Libraries/SAModel/GC/GCParameter.cs
@@ -1,7 +1,13 @@
-﻿using System;
-using System.IO;
-using System.Text;
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Drawing.Drawing2D;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace SAModel.GC
 {
@@ -121,41 +127,9 @@ namespace SAModel.GC
 			return result;
 		}
 
-		public void ToNJA(TextWriter writer)
+		public virtual void ToNJA(TextWriter writer)
 		{
-			switch (Type)
-			{
-				case ParameterType.VtxAttrFmt:
-					if (Data >> 16 != 0x5)
-					{
-						writer.WriteLine($"\tGJD_PARAM_IDX      ( {(GCVertexAttribute)(Data >> 16)}, {(byte)(Data >> 8)}, {(byte)Data} ),");
-					}
-					else
-					{
-						writer.WriteLine($"\tGJD_PARAM_IDX      ( {(GCVertexAttribute)(Data >> 16)}, {(byte)(Data >> 8)}, {(GCUVScale)(byte)Data} ),");
-					}
-					break;
-				case ParameterType.IndexAttributeFlags:
-					writer.WriteLine($"\tGJD_PARAM_VFLAGS   ( {((GCIndexAttributeFlags)Data).ToString().Replace(", ", " | ")} ),");
-					break;
-				case ParameterType.Lighting:
-					writer.WriteLine($"\tGJD_PARAM_LIGHT    ( {(short)Data}, {(byte)((Data >> 16) & 0xF)}, {(byte)((Data >> 20) & 0xF)}, {(byte)((Data >> 24) & 0xFF)} ),");
-					break;
-				case ParameterType.BlendAlpha: 
-					writer.WriteLine($"\tGJD_PARAM_BLEND    ( {(GCBlendModeControl)((Data >> 11) & 7)}, {(GCBlendModeControl)((Data >> 8) & 7)} ),");
-					break;
-				case ParameterType.DiffuseColor:
-					writer.WriteLine($"\tGJD_PARAM_DCOLOR   ( {(byte)Data}, {(byte)(Data >> 8)}, {(byte)(Data >> 16)}, {(byte)(Data >> 24)} ),");
-					break;
-				case ParameterType.Texture:
-					writer.WriteLine($"\tGJD_PARAM_TEX      ( {(short)Data}, {((GCTileMode)(short)(Data >> 16)).ToString().Replace(", ", " | ")} ),");
-					break;
-				case ParameterType.TextureTEVMode: writer.WriteLine($"\tGJD_PARAM_TEV      ( {(short)Data}, {(short)(Data >> 16)} ),");
-					break;
-				case ParameterType.TexCoordGen:
-					writer.WriteLine($"\tGJD_PARAM_TEXCOORD ( {(GCTexCoordID)((Data >> 16) & 0xFF)}, {(GCTexGenType)((Data >> 12) & 0xF)}, {(GCTexGenSrc)((Data >> 4) & 0xFF)}, {(GCTexGenMatrix)(Data & 0xF)} ),");
-					break;
-			}
+			writer.WriteLine($"GjMat     ( {(uint)Type}, {(uint)Data} ),");
 		}
 	}
 
@@ -242,6 +216,61 @@ namespace SAModel.GC
 			Unknown = unknown;
 			VertexAttribute = vertexAttrib;
 		}
+
+		public override void ToNJA(TextWriter writer)
+		{
+			string attr_str = VertexAttribute switch
+			{
+				GCVertexAttribute.PositionMatrixIdx => "GJ_VA_NULL",
+				GCVertexAttribute.Position => "GJ_VA_POS",
+				GCVertexAttribute.Normal => "GJ_VA_NRM",
+				GCVertexAttribute.Color0 => "GJ_VA_CLR0",
+				GCVertexAttribute.Color1 => "GJ_VA_CLR1",
+				GCVertexAttribute.Tex0 => "GJ_VA_TEX0",
+				GCVertexAttribute.Tex1 => "GJ_VA_TEX1",
+				GCVertexAttribute.Tex2 => "GJ_VA_TEX2",
+				GCVertexAttribute.Tex3 => "GJ_VA_TEX3",
+				GCVertexAttribute.Tex4 => "GJ_VA_TEX4",
+				GCVertexAttribute.Tex5 => "GJ_VA_TEX5",
+				GCVertexAttribute.Tex6 => "GJ_VA_TEX6",
+				GCVertexAttribute.Tex7 => "GJ_VA_TEX7",
+				_ => $"{(uint)VertexAttribute}"
+			};
+
+			uint comptype = (Data >> 12) & 0xF;
+			string comptype_str = comptype switch
+			{
+				0 => "GJ_POS_XY",
+				1 => "GJ_POS_XYZ",
+				2 => "GJ_NRM_XYZ",
+				3 => "GJ_NRM_NBT",
+				4 => "GJ_NRM_NBT3",
+				5 => "GJ_CLR_RGB",
+				6 => "GJ_CLR_RGBA",
+				7 => "GJ_TEX_S",
+				8 => "GJ_TEX_ST",
+				_ => $"{comptype}"
+			};
+
+			uint compsize = (Data >> 8) & 0xF;
+			string compsize_str = compsize switch
+			{
+				0 => "GJ_U8",
+				1 => "GJ_S8",
+				2 => "GJ_U16",
+				3 => "GJ_S16",
+				4 => "GJ_F32",
+				5 => "GJ_RGB565",
+				6 => "GJ_RGB8",
+				7 => "GJ_RGBX8",
+				8 => "GJ_RGBA4",
+				9 => "GJ_RGBA6",
+				10 => "GJ_RGBA8",
+				_ => $"{compsize}"
+			};
+
+			writer.WriteLine($"GjVtxAttr ( {attr_str}, {comptype_str}, {compsize_str}, {(uint)UVScale} ),");
+		}
 	}
 
 	/// <summary>
@@ -277,6 +306,52 @@ namespace SAModel.GC
 			IndexAttributes = flags;
 		}
 
+		public override void ToNJA(TextWriter writer)
+		{
+			var list = new List<string>();
+			for (int i = 0; i < 16; i++)
+			{
+				uint src = (Data >> (i * 2)) & 0b11;
+				if (src != 0)
+				{
+					string attr_str = i switch
+					{
+						0 => "GJ_VA_NULL",
+						1 => "GJ_VA_POS",
+						2 => "GJ_VA_NRM",
+						3 => "GJ_VA_CLR0",
+						4 => "GJ_VA_CLR1",
+						5 => "GJ_VA_TEX0",
+						6 => "GJ_VA_TEX1",
+						7 => "GJ_VA_TEX2",
+						8 => "GJ_VA_TEX3",
+						9 => "GJ_VA_TEX4",
+						10 => "GJ_VA_TEX5",
+						11 => "GJ_VA_TEX6",
+						12 => "GJ_VA_TEX7",
+						_ => $"{i}"
+					};
+
+					string src_str = src switch
+					{
+						1 => "GJ_DIRECT",
+						2 => "GJ_INDEX8",
+						3 => "GJ_INDEX16",
+					};
+
+					list.Add($"GjVtxDescAttr ( {attr_str}, {src_str} )");
+				}
+			}
+
+			if (list.Count == 0)
+			{
+				writer.WriteLine("GjVtxDesc ( NULL ),");
+			}
+			else
+			{
+				writer.WriteLine($"GjVtxDesc ( {string.Join(" | ", list)} ),");
+			}
+		}
 	}
 
 	/// <summary>
@@ -347,6 +422,11 @@ namespace SAModel.GC
 			LightingFlags = lightingFlags;
 			ShadowStencil = shadowStencil;
 		}
+
+		public override void ToNJA(TextWriter writer)
+		{
+			writer.WriteLine($"GjLight   ( {Data} ),");
+		}
 	}
 
 	/// <summary>
@@ -410,6 +490,46 @@ namespace SAModel.GC
 				Data |= (inst & 7) << 8;
 			}
 		}
+
+		public override void ToNJA(TextWriter writer)
+		{
+			uint mode = Data >> 14;
+
+			string mode_str = mode switch
+			{
+				0 => "GJ_BM_NONE",
+				1 => "GJ_BM_BLEND",
+				_ => $"{mode}"
+			};
+
+			string src_str = SourceAlpha switch
+			{
+				GCBlendModeControl.Zero => "GJ_BL_ZERO",
+				GCBlendModeControl.One => "GJ_BL_ONE",
+				GCBlendModeControl.SrcColor => "GJ_BL_SRCCLR",
+				GCBlendModeControl.InverseSrcColor => "GJ_BL_INVSRCCLR",
+				GCBlendModeControl.SrcAlpha => "GJ_BL_SRCALPHA",
+				GCBlendModeControl.InverseSrcAlpha => "GJ_BL_INVSRCALPHA",
+				GCBlendModeControl.DstAlpha => "GJ_BL_DSTALPHA",
+				GCBlendModeControl.InverseDstAlpha => "GJ_BL_INVDSTALPHA",
+				_ => $"{(uint)SourceAlpha}"
+			};
+
+			string dst_str = DestAlpha switch
+			{
+				GCBlendModeControl.Zero => "GJ_BL_ZERO",
+				GCBlendModeControl.One => "GJ_BL_ONE",
+				GCBlendModeControl.SrcColor => "GJ_BL_DSTCLR",
+				GCBlendModeControl.InverseSrcColor => "GJ_BL_INVDSTCLR",
+				GCBlendModeControl.SrcAlpha => "GJ_BL_SRCALPHA",
+				GCBlendModeControl.InverseSrcAlpha => "GJ_BL_INVSRCALPHA",
+				GCBlendModeControl.DstAlpha => "GJ_BL_DSTALPHA",
+				GCBlendModeControl.InverseDstAlpha => "GJ_BL_INVDSTALPHA",
+				_ => $"{(uint)SourceAlpha}"
+			};
+
+			writer.WriteLine($"GjBlend   ( {mode_str}, {src_str}, {dst_str} ),");
+		}
 	}
 
 	/// <summary>
@@ -438,6 +558,10 @@ namespace SAModel.GC
 		public DiffuseColorParameter() : base(ParameterType.DiffuseColor)
 		{
 			Data = uint.MaxValue; // White is default
+		}
+		public override void ToNJA(TextWriter writer)
+		{
+			writer.WriteLine($"GjDiffuse ( {DiffuseColor.Alpha}, {DiffuseColor.Red}, {DiffuseColor.Green}, {DiffuseColor.Blue} ),");
 		}
 	}
 
@@ -484,6 +608,29 @@ namespace SAModel.GC
 			TextureId = textureId;
 			Tile = tileMode;
 		}
+
+		public override void ToNJA(TextWriter writer)
+		{
+			uint wrap_s = (Data >> 16) & 3;
+			string wrap_s_str = wrap_s switch
+			{
+				0 => "GJ_CLAMP",
+				1 => "GJ_REPEAT",
+				2 => "GJ_MIRROR",
+				_ => $"{wrap_s}"
+			};
+
+			uint wrap_t = (Data >> 18) & 3;
+			string wrap_t_str = wrap_t switch
+			{
+				0 => "GJ_CLAMP",
+				1 => "GJ_REPEAT",
+				2 => "GJ_MIRROR",
+				_ => $"{wrap_t}"
+			};
+
+			writer.WriteLine($"GjTexID   ( {TextureId}, {wrap_s_str}, {wrap_t_str}, {(Data >> 13) & 3} ),");
+		}
 	}
 
 	/// <summary>
@@ -523,6 +670,40 @@ namespace SAModel.GC
 			// Default values
 			Unknown1 = 4;
 			Unknown2 = 0;
+		}
+
+		public override void ToNJA(TextWriter writer)
+		{
+			uint type = (Data >> 4) >> 0xF;
+			string type_str = type switch
+			{
+				0 => "GJ_TG_MTX3x4",
+				_ => $"{type}"
+			};
+
+			uint src = Data & 0xF;
+			string src_str = src switch
+			{
+				4 => "GJ_TG_TEX0",
+				_ => $"{src}"
+			};
+
+			uint texcoord = Data >> 12;
+			string texcoord_str = texcoord switch
+			{
+				0 => "GJ_TEXCOORD0",
+				_ => $"{texcoord}"
+			};
+
+			uint mtxsrc = Data >> 12;
+			string mtxsrc_str = mtxsrc switch
+			{
+				0 => "GJ_TEXMTX0",
+				10 => "GJ_IDENTITY",
+				_ => $"{mtxsrc}"
+			};
+
+			writer.WriteLine($"GjTexGen  ( {texcoord_str}, {type_str}, {src_str}, {mtxsrc_str} ),");
 		}
 	}
 
@@ -602,6 +783,37 @@ namespace SAModel.GC
 			TexGenType = texGenType;
 			TexGenSrc = texGenSrc;
 			MatrixId = matrixId;
+		}
+		
+		public override void ToNJA(TextWriter writer)
+		{
+			string matrixid_str = MatrixId switch
+			{
+				GCTexGenMatrix.Matrix0 => "GJ_TEXMTX0",
+				GCTexGenMatrix.Identity => "GJ_IDENTITY",
+				_ => $"{(uint)MatrixId}"
+			};
+
+			string texcoordid_str = TexCoordId switch
+			{
+				GCTexCoordID.TexCoord0 => "GJ_TEXCOORD0",
+				_ => $"{(uint)TexCoordId}"
+			};
+
+			string texgensrc_str = TexGenSrc switch
+			{
+				GCTexGenSrc.Tex0 => "GJ_TG_TEX0",
+				_ => $"{(uint)TexGenSrc}"
+			};
+
+			string texgentype_str = TexGenType switch
+			{
+				GCTexGenType.Matrix3x4 => "GJ_MTX3x4",
+				GCTexGenType.Matrix2x4 => "GJ_MTX2x4",
+				_ => $"{(uint)TexGenType}"
+			};
+
+			writer.WriteLine($"GjTexMtx  ( {matrixid_str}, {texcoordid_str}, {texgensrc_str}, {texgentype_str} ),");
 		}
 	}
 }

--- a/Libraries/SAModel/GC/GCPrimitive.cs
+++ b/Libraries/SAModel/GC/GCPrimitive.cs
@@ -284,26 +284,6 @@ namespace SAModel.GC
 			return result;
 		}
 
-		public void ToNJA(TextWriter writer)
-		{
-			var primtype = PrimitiveType switch
-			{
-				GCPrimitiveType.Triangles => "GJD_PRIM_TRIANGLE",
-				GCPrimitiveType.TriangleStrip => "GJD_PRIM_TRISTRIP",
-				GCPrimitiveType.TriangleFan => "GJD_PRIM_TRIFAN",
-				GCPrimitiveType.Lines => "GJD_PRIM_LINE",
-				GCPrimitiveType.LineStrip => "GJD_PRIM_LINESTRIP",
-				GCPrimitiveType.Points => "GJD_PRIM_POINT",
-				_ => null
-			};
-			
-			writer.WriteLine($"\t{primtype}({Loops.Count}),");
-			foreach (var loop in Loops)
-			{
-				writer.WriteLine($"\t{loop},");
-			}
-		}
-
 		/// <summary>
 		/// Convert the primitive into a triangle list
 		/// </summary>

--- a/Libraries/SAModel/GC/GCVertexSet.cs
+++ b/Libraries/SAModel/GC/GCVertexSet.cs
@@ -321,20 +321,20 @@ namespace SAModel.GC
 			switch (Attribute)
 			{
 				case GCVertexAttribute.Position:
-					vertType = "POINT";
-					vertType2 = "POSITION   ";
+					vertType = "VERT ";
+					vertType2 = "POINT      ";
 					break;
 				case GCVertexAttribute.Normal:
-					vertType = "NORMAL";
-					vertType2 = "NORMAL     ";
+					vertType = "NORM ";
+					vertType2 = "NORMAL      ";
 					break;
 				case GCVertexAttribute.Color0:
-					vertType = "COLOR";
-					vertType2 = "COLOR0     ";
+					vertType = "ARGB ";
+					vertType2 = "VERTCOLOR      ";
 					break;
 				case GCVertexAttribute.Tex0:
-					vertType = "UV";
-					vertType2 = "TEX0       ";
+					vertType = "UV ";
+					vertType2 = "VERTUV      ";
 					break;
 			}
 			
@@ -353,19 +353,24 @@ namespace SAModel.GC
 		{
 			var vertType = Attribute switch
 			{
-				GCVertexAttribute.Position => "POSITION",
-				GCVertexAttribute.Normal => "NORMAL",
-				GCVertexAttribute.Color0 => "COLOR0",
-				GCVertexAttribute.Tex0 => "TEX0",
+				GCVertexAttribute.Position => "GJ_VA_POS",
+				GCVertexAttribute.Normal => "GJ_VA_NRM",
+				GCVertexAttribute.Color0 => "GJ_VA_CLR0",
+				GCVertexAttribute.Tex0 => "GJ_VA_TEX0",
 				_ => null
 			};
 
-			writer.WriteLine($"\tVertAttr     {vertType},");
-			writer.WriteLine($"\tElementSize  {StructSize},");
-			writer.WriteLine($"\tPoints       {Data.Count},");
-			writer.WriteLine($"\tType         ( {StructType}, {DataType} ),");
-			writer.WriteLine($"\tName         {DataName},");
-			writer.WriteLine($"\tCheckSize    {Data.Count * StructSize},{Environment.NewLine}");
+			writer.WriteLine("ATTRSTART");
+			writer.WriteLine($"GjId         {vertType},");
+			writer.WriteLine($"GjStride     {StructSize},");
+			writer.WriteLine($"GjCount      {Data.Count},");
+
+			var structure = (uint)StructType;
+			structure |= (uint)((byte)DataType << 4);
+			writer.WriteLine($"GjAttrflags  {structure},");
+			writer.WriteLine($"GjBaseptr    {DataName},");
+			writer.WriteLine($"GjSize       {Data.Count * StructSize},");
+			writer.WriteLine($"ATTREND{Environment.NewLine}");
 		}
 
 		public GCVertexSet Clone()

--- a/Libraries/SAModel/NJS_OBJECT.cs
+++ b/Libraries/SAModel/NJS_OBJECT.cs
@@ -650,7 +650,7 @@ namespace SAModel
 				else if (isChunk)
 					writer.WriteLine("CNKOBJECT_START" + Environment.NewLine);
 				else if (isGinja)
-					writer.WriteLine("GCOBJECT_START" + Environment.NewLine);
+					writer.WriteLine("GJOBJECT_START" + Environment.NewLine);
 				else if (isXinja)
 					writer.WriteLine("XBOBJECT_START" + Environment.NewLine);
 			}
@@ -696,7 +696,7 @@ namespace SAModel
 				else if (isChunk)
 					writer.Write("CNKOBJECT  ");
 				else if (isGinja)
-					writer.Write("GCOBJECT    ");
+					writer.Write("GJOBJECT    ");
 				else if (isXinja)
 					writer.Write("XBOBJECT    ");
 
@@ -745,7 +745,7 @@ namespace SAModel
 				else if (isChunk)
 					writer.WriteLine("CNKModel   " + (Attach != null ? Attach.Name.MakeIdentifier() : "NULL") + ",");
 				else if (isGinja)
-					writer.WriteLine("GINJAModel " + (Attach != null ? Attach.Name.MakeIdentifier() : "NULL") + ",");
+					writer.WriteLine("GjModel " + (Attach != null ? Attach.Name.MakeIdentifier() : "NULL") + ",");
 				else if (isXinja)
 					writer.WriteLine("XINJAModel " + (Attach != null ? Attach.Name.MakeIdentifier() : "NULL") + ",");
 				writer.WriteLine("OPosition  {0},", Position.ToNJA());
@@ -765,7 +765,7 @@ namespace SAModel
 				else if (isChunk)
 					writer.WriteLine("CNKOBJECT_END");
 				else if (isGinja)
-					writer.WriteLine("GCOBJECT_END");
+					writer.WriteLine("GJOBJECT_END");
 				else if (isXinja)
 					writer.WriteLine("XBOBJECT_END");
 


### PR DESCRIPTION
Example output:

```c
GJOBJECT_START

POINT      position_00CDB3A8[]
START
	VERT (  0.000058F, -1513.136719F,  0.000013F ),
	//...
END

VERTCOLOR      vcolor_00CDB900[]
START
	ARGB ( 255, 255, 255, 255 ),
	//...
END

VERTUV      uv_00CDBAC8[]
START
	UV ( 2019, -718 ),
	//...
END

GJARRAY      vertex_00CDBED8[]
START

ATTRSTART
GjId         GJ_VA_POS,
GjStride     12,
GjCount      114,
GjAttrflags  65,
GjBaseptr    position_00CDB3A8,
GjSize       1368,
ATTREND

ATTRSTART
GjId         GJ_VA_CLR0,
GjStride     4,
GjCount      114,
GjAttrflags  166,
GjBaseptr    vcolor_00CDB900,
GjSize       456,
ATTREND

ATTRSTART
GjId         GJ_VA_TEX0,
GjStride     4,
GjCount      260,
GjAttrflags  56,
GjBaseptr    uv_00CDBAC8,
GjSize       1040,
ATTREND

ATTRSTART
GjId         GJ_VA_NULL,
ATTREND

END

GJMATERIAL   parameter_00CDBF18[]
START
GjVtxAttr ( GJ_VA_POS, GJ_POS_XYZ, GJ_F32, 0 ),
GjVtxAttr ( GJ_VA_CLR0, GJ_CLR_RGBA, GJ_RGBA8, 0 ),
GjVtxDesc ( GjVtxDescAttr ( GJ_VA_POS, GJ_INDEX8 ) | GjVtxDescAttr ( GJ_VA_CLR0, GJ_INDEX8 ) | GjVtxDescAttr ( GJ_VA_TEX0, GJ_INDEX8 ) ),
GjVtxAttr ( GJ_VA_TEX0, GJ_TEX_ST, GJ_S16, 8 ),
GjBlend   ( GJ_BM_NONE, GJ_BL_ZERO, GJ_BL_ZERO ),
GjLight   ( 69393 ),
GjDiffuse ( 0, 0, 0, 0 ),
GjTexID   ( 1, GJ_REPEAT, GJ_REPEAT, 0 ),
GjTexGen  ( GJ_TEXCOORD0, GJ_TG_MTX3x4, GJ_TG_TEX0, GJ_TEXMTX0 ),
GjTexMtx  ( GJ_IDENTITY, GJ_TEXCOORD0, GJ_TG_TEX0, GJ_MTX2x4 ),
END

GJDRAWLIST   primitive_00CDBF80[]
START
0x98, 0x0, 0x5, 0x41, 0x41, //...
END

GJMATERIAL   parameter_00CDBF68[]
START
GjTexID   ( 0, GJ_CLAMP, GJ_REPEAT, 0 ),
END

GJDRAWLIST   primitive_00CDC060[]
START
0x98, 0x0, 0x22, 0x67, 0x67, //...
END

GJMATERIAL   parameter_00CDBF70[]
START
GjVtxDesc ( GjVtxDescAttr ( GJ_VA_POS, GJ_INDEX8 ) | GjVtxDescAttr ( GJ_VA_CLR0, GJ_INDEX8 ) | GjVtxDescAttr ( GJ_VA_TEX0, GJ_INDEX16 ) ),
GjTexID   ( 2, GJ_REPEAT, GJ_REPEAT, 0 ),
END

GJDRAWLIST   primitive_00CDC220[]
START
0x98, 0x0, 0x5, 0x10, 0x10, 0x0, //…
END

GJMESHSET     opoly_00CDC360[]
START

MESHSTART
GjMats        parameter_00CDBF18,
GjNbMat       10,
GjDispList    primitive_00CDBF80,
GjSzDispList  224,
MESHEND

MESHSTART
GjMats        parameter_00CDBF68,
GjNbMat       1,
GjDispList    primitive_00CDC060,
GjSzDispList  448,
MESHEND

MESHSTART
GjMats        parameter_00CDBF70,
GjNbMat       2,
GjDispList    primitive_00CDC220,
GjSzDispList  320,
MESHEND

END

GJMODEL     attach_00CDA734[]
START
GjArray     vertex_00CDBED8,
GjVlist     NULL,
GjOMesh     opoly_00CDC360,
GjAMesh     NULL,
GjNbOMesh   3,
GjNbAMesh   0,
Center      0.000122F,  213.142517F,  0.000122F,
Radius      3261.492920F,
END

GJOBJECT    object_00CDC390[]
START
EvalFlags ( FEV_US|FEV_BR ),
GjModel attach_00CDA734,
OPosition  (  0.000000F, -732.000000F, -10.000000F ),
OAngle     (  0.000000F, -16.040077F,  0.000000F ),
OScale     (  1.000000F,  1.000000F,  1.000000F ),
Child       NULL,
Sibling     NULL,
OQuatRe    ( 0,000000 ),
END

GJOBJECT_END

DEFAULT_START

#ifndef DEFAULT_OBJECT_NAME
#define DEFAULT_OBJECT_NAME object_00CDC390
#endif

DEFAULT_END
```